### PR TITLE
feat(text): implements text treatments

### DIFF
--- a/docs/src/components/Breakpoints/Breakpoints.tsx
+++ b/docs/src/components/Breakpoints/Breakpoints.tsx
@@ -49,7 +49,7 @@ export const Breakpoints = () => {
     <Container>
       {Object.entries(breakpoints).map(([key, value]) => {
         return (
-          <Copy key={value} copy={`@include breakpoint('{key}');`}>
+          <Copy key={value} copy={`@include breakpoint(${key});`}>
             <Breakpoint value={value}>
               {key.toUpperCase()} — @include breakpoint('{key}') = @media
               (min-width: {value}) {"{"} ... {"}"}

--- a/docs/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/docs/src/components/GlobalStyles/GlobalStyles.tsx
@@ -1,4 +1,4 @@
-import { typography, space } from "@moda/tokens";
+import { typography, space, breakpoints } from "@moda/tokens";
 import { createGlobalStyle } from "styled-components";
 
 export const GlobalStyles = createGlobalStyle`
@@ -16,6 +16,11 @@ export const GlobalStyles = createGlobalStyle`
     margin: ${space.scale[7]};
     padding: ${space.scale[7]};
     font-size: ${typography["root-font-size"]};
+
+    @media (max-width: ${breakpoints.md}) {
+      margin: ${space.scale[7]} 0;
+      padding: ${space.scale[7]} 0;
+    }
   }
 
   body,

--- a/docs/src/components/Swatch/Swatch.tsx
+++ b/docs/src/components/Swatch/Swatch.tsx
@@ -76,7 +76,7 @@ export const Swatch: React.FC<Props> = ({
     const fg = getContrastYIQ({ r, g, b, a });
 
     return (
-      <Copy copy={`color("${name}")`}>
+      <Copy copy={`color(${name})`}>
         <Container bg={value} fg={fg} {...rest}>
           <span>{name}</span>
           <span>rgb({rgb.join(",")})</span>

--- a/docs/src/components/Typography/TextTreatments.tsx
+++ b/docs/src/components/Typography/TextTreatments.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import styled from "styled-components";
+import { space, typography, colors } from "@moda/tokens";
+
+import { Copy } from "../Copy";
+
+const Container = styled.div`
+  margin: ${space.scale[6]};
+`;
+
+const Specimen = styled.div`
+  display: flex;
+  align-items: center;
+  padding: ${space.scale[3]} 0;
+  border-bottom: 1px solid ${colors.all["forest-green"]};
+`;
+
+const Info = styled.div`
+  flex: 1;
+  padding: ${space.scale[3]} 0;
+  text-align: right;
+  font-size: ${typography["font-scale"][0]};
+`;
+
+const Render = styled.div`
+  flex: 4;
+  padding: ${space.scale[4]} ${space.scale[6]};
+`;
+
+export const TextTreatments: React.FC = () => {
+  return (
+    <Container>
+      {Object.entries(typography["text-treatments"]).map(([key, treatment]) => (
+        <Copy key={key} copy={`@include text(${key});`}>
+          <Specimen>
+            <Info>
+              @include text({key})<br />
+              font-size: {treatment["font-size"]}
+              <br />
+              line-height: {treatment["line-height"]}
+              <br />
+              letter-spacing: {treatment["letter-spacing"]}
+              {"text-transform" in treatment && (
+                <>
+                  <br />
+                  text-transform: {treatment["text-transform"]}
+                </>
+              )}
+            </Info>
+
+            <Render
+              style={{
+                fontSize: treatment["font-size"],
+                lineHeight: treatment["line-height"],
+                letterSpacing: treatment["letter-spacing"],
+                ...("text-transform" in treatment
+                  ? { textTransform: treatment["text-transform"] }
+                  : {})
+              }}
+            >
+              All their equipment and instruments are alive
+            </Render>
+          </Specimen>
+        </Copy>
+      ))}
+    </Container>
+  );
+};

--- a/docs/src/components/Typography/Typography.tsx
+++ b/docs/src/components/Typography/Typography.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { space, colors } from "@moda/tokens";
 
+import { TextTreatments } from "./TextTreatments";
 import { FontSize } from "./FontSize";
 import { LineHeight } from "./LineHeight";
 import { LetterSpacing } from "./LetterSpacing";
@@ -14,8 +15,12 @@ const Container = styled.div`
 
 export const Typography: React.FC = () => (
   <Container>
+    <TextTreatments />
+
     <FontSize />
+
     <LineHeight />
+
     <LetterSpacing />
   </Container>
 );

--- a/lib/assets/stylesheets/tokens/_functions.scss
+++ b/lib/assets/stylesheets/tokens/_functions.scss
@@ -29,3 +29,7 @@
 @function space($index) {
   @return __access__(map-get($space, "scale"), $index);
 }
+
+@function text-treatment($key) {
+  @return __fetch__(map-get($typography, "text-treatments"), $key);
+}

--- a/lib/assets/stylesheets/tokens/_mixins.scss
+++ b/lib/assets/stylesheets/tokens/_mixins.scss
@@ -1,12 +1,6 @@
 @import "variables";
 @import "functions";
 
-@mixin breakpoint($key) {
-  @media (min-width: __fetch__($breakpoints, $key)) {
-    @content;
-  }
-}
-
 @mixin global-styles() {
   html {
     box-sizing: border-box;
@@ -18,4 +12,25 @@
   *::after {
     box-sizing: inherit;
   }
+}
+
+@mixin compound($map) {
+  @each $prop, $value in $map {
+    @if type-of($value) == string {
+      #{$prop}: #{unquote($value)};
+    } @else {
+      #{$prop}: #{$value};
+    }
+  }
+}
+
+@mixin breakpoint($key, $prop: min-width) {
+  @media (#{$prop}: __fetch__($breakpoints, $key)) {
+    @content;
+  }
+}
+
+@mixin text($key, $font: sans) {
+  font-family: font-family($font);
+  @include compound(text-treatment($key));
 }

--- a/lib/assets/stylesheets/tokens/_utilities.scss
+++ b/lib/assets/stylesheets/tokens/_utilities.scss
@@ -6,8 +6,8 @@
 ///   The key to access
 /// @return {any} keyed value of `$map`
 @function __fetch__($map, $key) {
-  @if map-has-key($map, $key) {
-    @return map-get($map, $key);
+  @if map-has-key($map, quote($key)) {
+    @return map-get($map, quote($key));
   } @else {
     @error "ERROR: the key: '#{$key}' is not defined";
   }

--- a/lib/assets/stylesheets/tokens/variables/_typography.scss
+++ b/lib/assets/stylesheets/tokens/variables/_typography.scss
@@ -1,3 +1,5 @@
+@import "../utilities";
+
 $root-font-size: 16px;
 
 $font-stack-moda-sans: "Moda Operandi Sans", Arial, sans-serif;
@@ -24,10 +26,65 @@ $font-scale: (
   6rem
 );
 
+$text-treatments: (
+  h1: (
+    font-size: __access__($font-scale, 8),
+    line-height: __access__($line-heights, 0),
+    letter-spacing: __access__($letter-spacing, 0)
+  ),
+  h2: (
+    font-size: __access__($font-scale, 7),
+    line-height: __access__($line-heights, 1),
+    letter-spacing: __access__($letter-spacing, 0)
+  ),
+  h3: (
+    font-size: __access__($font-scale, 6),
+    line-height: __access__($line-heights, 0),
+    letter-spacing: __access__($letter-spacing, 0)
+  ),
+  h4: (
+    font-size: __access__($font-scale, 5),
+    line-height: __access__($line-heights, 1),
+    letter-spacing: __access__($letter-spacing, 0)
+  ),
+  h5: (
+    font-size: __access__($font-scale, 4),
+    line-height: __access__($line-heights, 2),
+    letter-spacing: __access__($letter-spacing, 0)
+  ),
+  h6: (
+    font-size: __access__($font-scale, 3),
+    line-height: __access__($line-heights, 2),
+    letter-spacing: __access__($letter-spacing, 1)
+  ),
+  h7: (
+    font-size: __access__($font-scale, 2),
+    line-height: __access__($line-heights, 2),
+    letter-spacing: __access__($letter-spacing, 2)
+  ),
+  body1: (
+    font-size: __access__($font-scale, 1),
+    line-height: __access__($line-heights, 3),
+    letter-spacing: __access__($letter-spacing, 2)
+  ),
+  body2: (
+    font-size: __access__($font-scale, 0),
+    line-height: __access__($line-heights, 2),
+    letter-spacing: __access__($letter-spacing, 2)
+  ),
+  eyebrow: (
+    font-size: __access__($font-scale, 0),
+    line-height: __access__($line-heights, 2),
+    letter-spacing: __access__($letter-spacing, 3),
+    text-transform: uppercase
+  )
+);
+
 $typography: (
   fonts: $fonts,
   line-heights: $line-heights,
   letter-spacing: $letter-spacing,
   font-scale: $font-scale,
-  root-font-size: $root-font-size
+  root-font-size: $root-font-size,
+  text-treatments: $text-treatments
 );

--- a/src/typography.ts
+++ b/src/typography.ts
@@ -36,5 +36,58 @@ export const typography = {
     "3.75rem",
     "6rem"
   ],
-  "root-font-size": "16px"
+  "root-font-size": "16px",
+  "text-treatments": {
+    "h1": {
+      "font-size": "6rem",
+      "line-height": 1.1,
+      "letter-spacing": 0
+    },
+    "h2": {
+      "font-size": "3.75rem",
+      "line-height": 1.2,
+      "letter-spacing": 0
+    },
+    "h3": {
+      "font-size": "3rem",
+      "line-height": 1.1,
+      "letter-spacing": 0
+    },
+    "h4": {
+      "font-size": "2rem",
+      "line-height": 1.2,
+      "letter-spacing": 0
+    },
+    "h5": {
+      "font-size": "1.5rem",
+      "line-height": 1.4,
+      "letter-spacing": 0
+    },
+    "h6": {
+      "font-size": "1.25rem",
+      "line-height": 1.4,
+      "letter-spacing": "0.02em"
+    },
+    "h7": {
+      "font-size": "1rem",
+      "line-height": 1.4,
+      "letter-spacing": "0.04em"
+    },
+    "body1": {
+      "font-size": "0.8125rem",
+      "line-height": 1.6,
+      "letter-spacing": "0.04em"
+    },
+    "body2": {
+      "font-size": "0.75rem",
+      "line-height": 1.4,
+      "letter-spacing": "0.04em"
+    },
+    "eyebrow": {
+      "font-size": "0.75rem",
+      "line-height": 1.4,
+      "letter-spacing": "0.1em",
+      "text-transform": "uppercase"
+    }
+  }
 };

--- a/testbed/style.scss
+++ b/testbed/style.scss
@@ -4,7 +4,11 @@
 
 body {
   margin: space(6) space(6);
-  font-family: font-family("sans");
-  background-color: color("canary");
-  font-size: font-size(1);
+  background-color: color(canary);
+  @include text(h1, $font: serif);
+
+  @include breakpoint(md, $prop: max-width) {
+    background-color: color(lilac);
+    font-family: font-family(sans);
+  }
 }


### PR DESCRIPTION
I thought at first this might not make sense in this repo; but I think it does as text treatments are less a complex mixin and more of a compound token. IE: I would want to use this data in say a styled-system implementation.