### PR TITLE
fix: renames body1bold => bold1

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ breakpoints;
 Accepts the name of a text treatment and, optionally, a font. Returns an object representing the CSS styles for that text treatment.
 
 ```tsx
-type TextTreatment = "display" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "body1" | "body2" | "eyebrow"
+type TextTreatment = "display" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "body1" | "bold1" | "body2" | "eyebrow"
 
 const text: (name: TextTreatment, font?: "serif" | "sans" | "code") => {
     "font-family": string;

--- a/lib/assets/stylesheets/tokens/variables/_typography.scss
+++ b/lib/assets/stylesheets/tokens/variables/_typography.scss
@@ -70,7 +70,7 @@ $text-treatments: (
     line-height: __access__($line-heights, 3),
     letter-spacing: __access__($letter-spacing, 2),
   ),
-  body1bold: (
+  bold1: (
     font-size: __access__($font-scale, 1),
     line-height: __access__($line-heights, 3),
     letter-spacing: __access__($letter-spacing, 3),

--- a/src/typography.ts
+++ b/src/typography.ts
@@ -85,7 +85,7 @@ export const typography = {
       "line-height": 1.6,
       "letter-spacing": "0.04em"
     },
-    "body1bold": {
+    "bold1": {
       "font-size": "0.8125rem",
       "line-height": 1.6,
       "letter-spacing": "0.1em",


### PR DESCRIPTION
This naming is a bit more appropriate since we're stepping outside of body1's letter-spacing.