### PR TITLE
fix: don't export includePaths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export { includePaths } from "./includePaths";
 export { colors } from "./colors";
 export { typography } from "./typography";
 export { space } from "./space";


### PR DESCRIPTION
`includePaths` is an internal utility that isn't used by anything and it uses 'path' that doesn't have a fallback with webpack 5 on client-side