### PR TITLE
feat(sass): fix deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,23 @@ npm install --save @moda/tokens
 Import the library and utilize the mixins or functions in your SCSS files:
 
 ```scss
-@import "~@moda/tokens";
+@use '~@moda/tokens';
 
 // Use functions to access values:
 p {
-  @include text(body1);
+  @include tokens.text(body1);
 }
 ```
 
 Import the library and utilize the values in TypeScript:
 
 ```tsx
-import { color } from "@moda/tokens";
+import { color } from '@moda/tokens';
 
-color("ink");
+color('ink');
 ```
 
-- **Netlify deploy config** is located here: https://github.com/ModaOperandi/tokens/blob/main/netlify.toml 
+- **Netlify deploy config** is located here: https://github.com/ModaOperandi/tokens/blob/main/netlify.toml
 
 - **Netlify site overview**: https://app.netlify.com/sites/moda-tokens/overview
 
@@ -96,15 +96,15 @@ Refer to the files in the [variables directory](https://github.com/ModaOperandi/
 
 Returns the font-stack associated with the key.
 
-#### `__dangerously-get-letter-spacing__($index)`
+#### `dangerously-get-letter-spacing($index)`
 
 Returns the letter-spacing associated with the index.
 
-#### `__dangerously-get-line-height__($index)`
+#### `dangerously-get-line-height($index)`
 
 Returns the line-height associated with the index.
 
-#### `__dangerously-get-font-size__($index)`
+#### `dangerously-get-font-size($index)`
 
 Returns the font-size associated with the index.
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -1,39 +1,39 @@
-import React from "react";
-import { Reset } from "styled-reset";
-import styled from "styled-components";
-import { colors, spacing, text } from "@moda/tokens";
+import React from 'react';
+import { Reset } from 'styled-reset';
+import styled from 'styled-components';
+import { colors, spacing, text } from '@moda/tokens';
 
-import { GlobalStyles } from "./components/GlobalStyles";
-import { NearestColor } from "./components/NearestColor";
-import { Breakpoints } from "./components/Breakpoints";
-import { Space } from "./components/Space";
-import { Typography } from "./components/Typography";
-import { Palette } from "./components/Palette";
+import { GlobalStyles } from './components/GlobalStyles';
+import { NearestColor } from './components/NearestColor';
+import { Breakpoints } from './components/Breakpoints';
+import { Space } from './components/Space';
+import { Typography } from './components/Typography';
+import { Palette } from './components/Palette';
 
 const Section = styled.section`
-  margin: ${spacing(8, "auto")};
+  margin: ${spacing(8, 'auto')};
 `;
 
 const H1 = styled.h1`
-  ${text("h4")}
+  ${text('h4')}
   margin: ${spacing(6, 0)};
   text-align: center;
 `;
 
 const H2 = styled.h2`
-  ${text("h4", "serif")}
+  ${text('h4', 'serif')}
   margin: ${spacing(6, 0)};
   text-align: center;
 `;
 
 const P = styled.p`
-  ${text("body1")}
+  ${text('body1')}
   margin: ${spacing(6)};
   text-align: center;
 `;
 
 const Code = styled.code`
-  ${text("body2", "code")}
+  ${text('body2', 'code')}
 `;
 
 export const App: React.FC = () => (
@@ -47,32 +47,28 @@ export const App: React.FC = () => (
     <NearestColor />
 
     <Section>
-      <H2 id="spacing">Spacing Scale</H2>
+      <H2 id='spacing'>Spacing Scale</H2>
 
-      <P>
-        Utilize units from the scale over hardcoded-values to ensure a
-        consistent rhythm.
-      </P>
+      <P>Utilize units from the scale over hardcoded-values to ensure a consistent rhythm.</P>
 
       <Space />
     </Section>
 
     <Section>
-      <H2 id="typography">Typography</H2>
+      <H2 id='typography'>Typography</H2>
 
       <P>
-        Utilize codified text treatments over composing individual properties.
-        Specific font-sizes require specific line-heights and letter-spacings.
-        Getters for individual properties (font-size, line-height, etc.) follow
-        the naming convention <Code>__dangerously-get-property-name__</Code> to
-        discourage their direct usage.
+        Utilize codified text treatments over composing individual properties. Specific font-sizes
+        require specific line-heights and letter-spacings. Getters for individual properties
+        (font-size, line-height, etc.) follow the naming convention{' '}
+        <Code>dangerously-get-property-name</Code> to discourage their direct usage.
       </P>
 
       <Typography />
     </Section>
 
     <Section>
-      <H2 id="colors">Colors</H2>
+      <H2 id='colors'>Colors</H2>
 
       <P>Utilize named color tokens instead of hexadecimal values.</P>
 
@@ -82,12 +78,9 @@ export const App: React.FC = () => (
     </Section>
 
     <Section>
-      <H2 id="breakpoints">Breakpoints</H2>
+      <H2 id='breakpoints'>Breakpoints</H2>
 
-      <P>
-        Utilize breakpoints mixin to ensure components break at the same places
-        across apps.
-      </P>
+      <P>Utilize breakpoints mixin to ensure components break at the same places across apps.</P>
 
       <Breakpoints />
     </Section>

--- a/docs/src/components/Typography/Typography.tsx
+++ b/docs/src/components/Typography/Typography.tsx
@@ -1,13 +1,13 @@
-import React from "react";
-import styled from "styled-components";
-import { spacing, color, typography, text } from "@moda/tokens";
-import { TextTreatments } from "./TextTreatments";
-import { ValueTable } from "./ValueTable";
+import React from 'react';
+import styled from 'styled-components';
+import { spacing, color, typography, text } from '@moda/tokens';
+import { TextTreatments } from './TextTreatments';
+import { ValueTable } from './ValueTable';
 
 const Container = styled.div`
   padding: ${spacing(5)};
-  color: ${color("ink")};
-  background-color: ${color("seafoam")};
+  color: ${color('ink')};
+  background-color: ${color('seafoam')};
 `;
 
 const Rule = styled.hr`
@@ -19,7 +19,7 @@ const Rule = styled.hr`
 `;
 
 const H3 = styled.h3`
-  ${text("h6")}
+  ${text('h6')}
   margin-bottom: ${spacing(6)};
 `;
 
@@ -29,33 +29,24 @@ export const Typography: React.FC = () => (
 
     <Rule />
 
-    <TextTreatments font="serif" />
+    <TextTreatments font='serif' />
 
     <Rule />
 
     <H3>Font Size</H3>
 
-    <ValueTable
-      getter="__dangerously-get-font-size__"
-      values={typography["font-scale"]}
-    />
+    <ValueTable getter='dangerously-get-font-size' values={typography['font-scale']} />
 
     <Rule />
 
     <H3>Line Height</H3>
 
-    <ValueTable
-      getter="__dangerously-get-line-height__"
-      values={typography["line-heights"]}
-    />
+    <ValueTable getter='dangerously-get-line-height' values={typography['line-heights']} />
 
     <Rule />
 
     <H3>Letter Spacing</H3>
 
-    <ValueTable
-      getter="__dangerously-get-letter-spacing__"
-      values={typography["letter-spacing"]}
-    />
+    <ValueTable getter='dangerously-get-letter-spacing' values={typography['letter-spacing']} />
   </Container>
 );

--- a/lib/assets/stylesheets/_tokens.scss
+++ b/lib/assets/stylesheets/_tokens.scss
@@ -1,3 +1,3 @@
-@import "tokens/functions";
-@import "tokens/mixins";
-@import "tokens/variables";
+@forward 'tokens/functions';
+@forward 'tokens/mixins';
+@forward 'tokens/variables';

--- a/lib/assets/stylesheets/tokens/_functions.scss
+++ b/lib/assets/stylesheets/tokens/_functions.scss
@@ -1,12 +1,15 @@
-@import "utilities";
-@import "variables";
+@use 'sass:list';
+@use 'sass:map';
+@use 'sass:meta';
+@use 'utilities';
+@use 'variables';
 
 @function font-family($key) {
-  @return __fetch__(map-get($typography, "fonts"), $key);
+  @return utilities.fetch(map.get(variables.$typography, 'fonts'), $key);
 }
 
 @function color($key, $opacity: null) {
-  $value: __fetch__(map-get($colors, "all"), $key);
+  $value: utilities.fetch(map.get(variables.$colors, 'all'), $key);
   @if $opacity {
     @return rgba($value, $opacity);
   } @else {
@@ -14,40 +17,40 @@
   }
 }
 
-// `__dangerously-get-` functions are named this way to discourage their use.
+// `dangerously-get-` functions are named this way to discourage their use.
 // Users of this library should always be utilizing codified text treatments via the `text` mixin.
-@function __dangerously-get-letter-spacing__($index) {
-  @return __access__(map-get($typography, "letter-spacing"), $index);
+@function dangerously-get-letter-spacing($index) {
+  @return utilities.access(map.get(variables.$typography, 'letter-spacing'), $index);
 }
 
-@function __dangerously-get-line-height__($index) {
-  @return __access__(map-get($typography, "line-heights"), $index);
+@function dangerously-get-line-height($index) {
+  @return utilities.access(map.get(variables.$typography, 'line-heights'), $index);
 }
 
-@function __dangerously-get-font-size__($index) {
-  @return __access__(map-get($typography, "font-scale"), $index);
+@function dangerously-get-font-size($index) {
+  @return utilities.access(map.get(variables.$typography, 'font-scale'), $index);
 }
 
 @function space($indexOrKey) {
-  @if type-of($indexOrKey) != number {
-    @return __fetch__(map-get($space, "map"), $indexOrKey);
+  @if meta.type-of($indexOrKey) != number {
+    @return utilities.fetch(map.get(variables.$space, 'map'), $indexOrKey);
   }
 
-  @return __access__(map-get($space, "scale"), $indexOrKey);
+  @return utilities.access(map.get(variables.$space, 'scale'), $indexOrKey);
 }
 
 @function spacing($indices...) {
   $spacing: ();
 
   @each $index in $indices {
-    $spacing: append($spacing, space($index));
+    $spacing: list.append($spacing, space($index));
   }
 
   @return $spacing;
 }
 
 @function text-treatment($key) {
-  @return __fetch__(map-get($typography, "text-treatments"), $key);
+  @return utilities.fetch(map.get(variables.$typography, 'text-treatments'), $key);
 }
 
 /// @param {prop (string)} $prop
@@ -56,12 +59,12 @@
 ///   Either list of properties
 /// @return {string | null} declares !important or not
 @function important($important: false, $prop: null) {
-  @if type-of($important) == bool {
+  @if meta.type-of($important) == bool {
     @return if($important, !important, null);
   }
 
-  @if type-of($important) == list {
-    @return if(index($important, $prop), !important, null);
+  @if meta.type-of($important) == list {
+    @return if(list.index($important, $prop), !important, null);
   }
 
   @return null;

--- a/lib/assets/stylesheets/tokens/_mixins.scss
+++ b/lib/assets/stylesheets/tokens/_mixins.scss
@@ -1,31 +1,34 @@
-@import "variables";
-@import "functions";
+@use 'sass:meta';
+@use 'sass:string';
+@use 'variables';
+@use 'functions';
+@use 'utilities';
 
 @mixin compound($map, $important: false) {
   @each $prop, $value in $map {
-    @if type-of($value) == string {
-      #{$prop}: #{unquote($value)} important($important, $prop);
+    @if meta.type-of($value) == string {
+      #{$prop}: #{string.unquote($value)} functions.important($important, $prop);
     } @else {
-      #{$prop}: #{$value} important($important, $prop);
+      #{$prop}: #{$value} functions.important($important, $prop);
     }
   }
 }
 
 @mixin breakpoint($key, $prop: min-width) {
   @if $prop == max-width {
-    @media (#{$prop}: __fetch__($breakpoints, $key)) {
+    @media (#{$prop}: utilities.fetch(variables.$breakpoints, $key)) {
       @content;
     }
   }
 
   @if $prop == min-width {
-    @media (#{$prop}: (__fetch__($breakpoints, $key) + $root-one-px)) {
+    @media (#{$prop}: (utilities.fetch(variables.$breakpoints, $key) + variables.$root-one-px)) {
       @content;
     }
   }
 }
 
 @mixin text($key, $font: sans, $important: false) {
-  font-family: font-family($font) important($important, font-family);
-  @include compound(text-treatment($key), $important);
+  font-family: functions.font-family($font) functions.important($important, font-family);
+  @include compound(functions.text-treatment($key), $important);
 }

--- a/lib/assets/stylesheets/tokens/_utilities.scss
+++ b/lib/assets/stylesheets/tokens/_utilities.scss
@@ -1,3 +1,6 @@
+@use "sass:list";
+@use "sass:map";
+@use "sass:string";
 @use 'sass:math';
 
 /// Returns the named value of a map. Throws an error if it does not exist.
@@ -7,9 +10,9 @@
 /// @param {string} $key
 ///   The key to access
 /// @return {any} keyed value of `$map`
-@function __fetch__($map, $key) {
-  @if map-has-key($map, quote($key)) {
-    @return map-get($map, quote($key));
+@function fetch($map, $key) {
+  @if map.has-key($map, string.quote($key)) {
+    @return map.get($map, string.quote($key));
   } @else {
     @error "ERROR: the key: '#{$key}' is not defined";
   }
@@ -22,8 +25,8 @@
 /// @param {integer (unitless)} $index
 ///   The 0-based index to access
 /// @return {any} positional value of `$list`
-@function __access__($list, $index) {
-  @return nth($list, $index + 1);
+@function access($list, $index) {
+  @return list.nth($list, $index + 1);
 }
 
 /// Merge multiple maps
@@ -31,14 +34,14 @@
 /// @param {maps} $maps
 ///   The list of maps to merge
 /// @return {map} merged map
-@function __merge__($maps...) {
+@function merge($maps...) {
   $collection: ();
   @each $map in $maps {
-    $collection: map-merge($collection, $map);
+    $collection: map.merge($collection, $map);
   }
   @return $collection;
 }
 
-@function __strip-units__($value) {
+@function strip-units($value) {
   @return math.div($value, ($value * 0 + 1));
 }

--- a/lib/assets/stylesheets/tokens/_variables.scss
+++ b/lib/assets/stylesheets/tokens/_variables.scss
@@ -1,4 +1,4 @@
-@import "variables/typography";
-@import "variables/colors";
-@import "variables/space";
-@import "variables/breakpoints";
+@forward 'variables/typography';
+@forward 'variables/colors';
+@forward 'variables/space';
+@forward 'variables/breakpoints';

--- a/lib/assets/stylesheets/tokens/variables/_colors.scss
+++ b/lib/assets/stylesheets/tokens/variables/_colors.scss
@@ -1,3 +1,5 @@
+@use "../utilities";
+
 $colors-greyscale: (
   'coal': #000000,
   'ink': #191a1b,
@@ -45,7 +47,7 @@ $colors-mens: (
   'canary': #f0f659
 );
 
-$colors-all: __merge__($colors-greyscale, $colors-ui, $colors-global, $colors-womens, $colors-mens);
+$colors-all: utilities.merge($colors-greyscale, $colors-ui, $colors-global, $colors-womens, $colors-mens);
 
 $colors: (
   all: $colors-all,

--- a/lib/assets/stylesheets/tokens/variables/_space.scss
+++ b/lib/assets/stylesheets/tokens/variables/_space.scss
@@ -1,46 +1,48 @@
+@use "../utilities";
+
 $spacing-scale: (
   // 0 - 0x
-    0rem,
+  0rem,
   // 1 - quarter-x
-    0.25rem,
+  0.25rem,
   // 2 - half-x
-    0.5rem,
+  0.5rem,
   // 3 - three-quarter-x
-    0.75rem,
+  0.75rem,
   // 4 - 1x
-    1rem,
+  1rem,
   // 5 - one-and-a-half-x
-    1.5rem,
+  1.5rem,
   // 6 - 2x
-    2rem,
+  2rem,
   // 7 - 3x
-    3rem,
+  3rem,
   // 8 - 4x
-    4rem,
+  4rem,
   // 9 - 6x
-    6rem,
+  6rem,
   // 10 - 8x
-    8rem,
+  8rem,
   // 11 - 12x
-    12rem,
+  12rem,
   // 12 - 24x
-    24rem
+  24rem
 );
 
 $spacing-map: (
-  "0x": __access__($spacing-scale, 0),
-  "quarter-x": __access__($spacing-scale, 1),
-  "half-x": __access__($spacing-scale, 2),
-  "three-quarter-x": __access__($spacing-scale, 3),
-  "1x": __access__($spacing-scale, 4),
-  "one-and-a-half-x": __access__($spacing-scale, 5),
-  "2x": __access__($spacing-scale, 6),
-  "3x": __access__($spacing-scale, 7),
-  "4x": __access__($spacing-scale, 8),
-  "6x": __access__($spacing-scale, 9),
-  "8x": __access__($spacing-scale, 10),
-  "12x": __access__($spacing-scale, 11),
-  "24x": __access__($spacing-scale, 12)
+  '0x': utilities.access($spacing-scale, 0),
+  'quarter-x': utilities.access($spacing-scale, 1),
+  'half-x': utilities.access($spacing-scale, 2),
+  'three-quarter-x': utilities.access($spacing-scale, 3),
+  '1x': utilities.access($spacing-scale, 4),
+  'one-and-a-half-x': utilities.access($spacing-scale, 5),
+  '2x': utilities.access($spacing-scale, 6),
+  '3x': utilities.access($spacing-scale, 7),
+  '4x': utilities.access($spacing-scale, 8),
+  '6x': utilities.access($spacing-scale, 9),
+  '8x': utilities.access($spacing-scale, 10),
+  '12x': utilities.access($spacing-scale, 11),
+  '24x': utilities.access($spacing-scale, 12)
 );
 
 $space: (

--- a/lib/assets/stylesheets/tokens/variables/_typography.scss
+++ b/lib/assets/stylesheets/tokens/variables/_typography.scss
@@ -1,93 +1,83 @@
 @use 'sass:math';
-@import "../utilities";
+@use '../utilities';
 
 $root-font-size: 16px;
-$root-one-px: math.div(1, __strip-units__($root-font-size));
+$root-one-px: math.div(1, utilities.strip-units($root-font-size));
 
-$font-stack-moda-sans: "Moda Operandi Sans", Arial, sans-serif;
-$font-stack-moda-serif: "Moda Operandi Serif", "Times New Roman", Times, serif;
-$font-stack-code: Menlo, Monaco, Consolas, "Courier New", monospace;
+$font-stack-moda-sans: 'Moda Operandi Sans', Arial, sans-serif;
+$font-stack-moda-serif: 'Moda Operandi Serif', 'Times New Roman', Times, serif;
+$font-stack-code: Menlo, Monaco, Consolas, 'Courier New', monospace;
 
 $fonts: (
   sans: $font-stack-moda-sans,
   serif: $font-stack-moda-serif,
-  code: $font-stack-code,
+  code: $font-stack-code
 );
 
 $line-heights: 1.1, 1.2, 1.4, 1.6;
 
 $letter-spacing: 0, 0.02em, 0.04em, 0.1em;
 
-$font-scale: (
-  0.75rem,
-  0.8125rem,
-  1rem,
-  1.25rem,
-  1.5rem,
-  2rem,
-  3rem,
-  3.75rem,
-  6rem
-);
+$font-scale: (0.75rem, 0.8125rem, 1rem, 1.25rem, 1.5rem, 2rem, 3rem, 3.75rem, 6rem);
 
 $text-treatments: (
   display: (
-    font-size: __access__($font-scale, 8),
-    line-height: __access__($line-heights, 0),
-    letter-spacing: __access__($letter-spacing, 0),
+    font-size: utilities.access($font-scale, 8),
+    line-height: utilities.access($line-heights, 0),
+    letter-spacing: utilities.access($letter-spacing, 0)
   ),
   h1: (
-    font-size: __access__($font-scale, 7),
-    line-height: __access__($line-heights, 1),
-    letter-spacing: __access__($letter-spacing, 0),
+    font-size: utilities.access($font-scale, 7),
+    line-height: utilities.access($line-heights, 1),
+    letter-spacing: utilities.access($letter-spacing, 0)
   ),
   h2: (
-    font-size: __access__($font-scale, 6),
-    line-height: __access__($line-heights, 0),
-    letter-spacing: __access__($letter-spacing, 0),
+    font-size: utilities.access($font-scale, 6),
+    line-height: utilities.access($line-heights, 0),
+    letter-spacing: utilities.access($letter-spacing, 0)
   ),
   h3: (
-    font-size: __access__($font-scale, 5),
-    line-height: __access__($line-heights, 1),
-    letter-spacing: __access__($letter-spacing, 0),
+    font-size: utilities.access($font-scale, 5),
+    line-height: utilities.access($line-heights, 1),
+    letter-spacing: utilities.access($letter-spacing, 0)
   ),
   h4: (
-    font-size: __access__($font-scale, 4),
-    line-height: __access__($line-heights, 2),
-    letter-spacing: __access__($letter-spacing, 0),
+    font-size: utilities.access($font-scale, 4),
+    line-height: utilities.access($line-heights, 2),
+    letter-spacing: utilities.access($letter-spacing, 0)
   ),
   h5: (
-    font-size: __access__($font-scale, 3),
-    line-height: __access__($line-heights, 2),
-    letter-spacing: __access__($letter-spacing, 1),
+    font-size: utilities.access($font-scale, 3),
+    line-height: utilities.access($line-heights, 2),
+    letter-spacing: utilities.access($letter-spacing, 1)
   ),
   h6: (
-    font-size: __access__($font-scale, 2),
-    line-height: __access__($line-heights, 2),
-    letter-spacing: __access__($letter-spacing, 2),
+    font-size: utilities.access($font-scale, 2),
+    line-height: utilities.access($line-heights, 2),
+    letter-spacing: utilities.access($letter-spacing, 2)
   ),
   body1: (
-    font-size: __access__($font-scale, 1),
-    line-height: __access__($line-heights, 3),
-    letter-spacing: __access__($letter-spacing, 2),
+    font-size: utilities.access($font-scale, 1),
+    line-height: utilities.access($line-heights, 3),
+    letter-spacing: utilities.access($letter-spacing, 2)
   ),
   bold1: (
-    font-size: __access__($font-scale, 1),
-    line-height: __access__($line-heights, 3),
-    letter-spacing: __access__($letter-spacing, 3),
-    font-weight: bold,
+    font-size: utilities.access($font-scale, 1),
+    line-height: utilities.access($line-heights, 3),
+    letter-spacing: utilities.access($letter-spacing, 3),
+    font-weight: bold
   ),
   body2: (
-    font-size: __access__($font-scale, 0),
-    line-height: __access__($line-heights, 2),
-    letter-spacing: __access__($letter-spacing, 2),
+    font-size: utilities.access($font-scale, 0),
+    line-height: utilities.access($line-heights, 2),
+    letter-spacing: utilities.access($letter-spacing, 2)
   ),
   eyebrow: (
-    font-size: __access__($font-scale, 0),
-    line-height: __access__($line-heights, 2),
-    letter-spacing: __access__($letter-spacing, 3),
-    text-transform: uppercase,
-  ),
+    font-size: utilities.access($font-scale, 0),
+    line-height: utilities.access($line-heights, 2),
+    letter-spacing: utilities.access($letter-spacing, 3),
+    text-transform: uppercase
+  )
 );
 
 $typography: (
@@ -96,5 +86,5 @@ $typography: (
   letter-spacing: $letter-spacing,
   font-scale: $font-scale,
   root-font-size: $root-font-size,
-  text-treatments: $text-treatments,
+  text-treatments: $text-treatments
 );

--- a/scripts/export.scss
+++ b/scripts/export.scss
@@ -1,37 +1,35 @@
-@import "../lib/assets/stylesheets/tokens";
+@use '../lib/assets/stylesheets/tokens';
 
 // Exports out any SASS maps to a TypeScript files
 $__export__: export(
-  "src/colors.ts",
-  $colors,
+  'src/colors.ts',
+  tokens.$colors,
   (
-    prefix: "// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const colors = ",
-    suffix: ";"
+    prefix: '// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const colors = ',
+    suffix: ';'
   )
 );
 $__export__: export(
-  "src/typography.ts",
-  $typography,
+  'src/typography.ts',
+  tokens.$typography,
   (
-    prefix:
-      "// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const typography = ",
-    suffix: ";"
+    prefix: '// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const typography = ',
+    suffix: ';'
   )
 );
 $__export__: export(
-  "src/space.ts",
-  $space,
+  'src/space.ts',
+  tokens.$space,
   (
-    prefix: "// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const space = ",
-    suffix: ";"
+    prefix: '// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const space = ',
+    suffix: ';'
   )
 );
 $__export__: export(
-  "src/breakpoints.ts",
-  $breakpoints,
+  'src/breakpoints.ts',
+  tokens.$breakpoints,
   (
-    prefix:
-      "// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const breakpoints = ",
-    suffix: ";"
+    prefix: '// THIS FILE IS AUTO-GENERATED. DO NOT EDIT.\a export const breakpoints = ',
+    suffix: ';'
   )
 );

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,1 +1,1 @@
-@import '../lib/assets/stylesheets/tokens';
+@forward '../lib/assets/stylesheets/tokens';

--- a/test/css.test.js
+++ b/test/css.test.js
@@ -1,32 +1,30 @@
-const path = require("path");
-const sass = require("sass");
+const path = require('path');
+const sass = require('sass');
 
 const compile = css =>
   sass
-    .renderSync({
-      data: `@import 'tokens';${css}`,
-      includePaths: [path.join(__dirname, "../lib/assets/stylesheets")],
-      outputStyle: "compressed"
+    .compileString(`@use 'tokens';${css}`, {
+      loadPaths: [path.join(__dirname, '../lib/assets/stylesheets')],
+      style: 'compressed'
     })
-    .css.toString()
-    .trim();
+    .css.trim();
 
-describe("~@moda/tokens", () => {
-  it("compiles correctly", () => {
+describe('~@moda/tokens', () => {
+  it('compiles correctly', () => {
     expect(
       compile(`
 
 body {
-  @include text(h1, $font: serif);
+  @include tokens.text(h1, $font: serif);
 
-  margin: space(6) space("2x"); // same value => 2rem
-  background-color: color(canary);
+  margin: tokens.space(6) tokens.space("2x"); // same value => 2rem
+  background-color: tokens.color(canary);
 
-  @include breakpoint(md, $prop: max-width) {
-    @include text(h1, $font: sans, $important: true);
+  @include tokens.breakpoint(md, $prop: max-width) {
+    @include tokens.text(h1, $font: sans, $important: true);
 
-    background-color: color(lilac);
-    font-family: font-family(sans);
+    background-color: tokens.color(lilac);
+    font-family: tokens.font-family(sans);
   }
 }
 
@@ -36,73 +34,61 @@ body {
     );
   });
 
-  describe("functions", () => {
-    describe("space", () => {
-      it("supports index access", () => {
-        expect(compile(`body { padding: space(4) }`)).toEqual(
-          "body{padding:1rem}"
-        );
+  describe('functions', () => {
+    describe('space', () => {
+      it('supports index access', () => {
+        expect(compile(`body { padding: tokens.space(4) }`)).toEqual('body{padding:1rem}');
       });
 
-      it("supports named access", () => {
+      it('supports named access', () => {
         expect(
-          compile(`body { padding: space('1x') space('three-quarter-x') }`)
-        ).toEqual("body{padding:1rem .75rem}");
+          compile(`body { padding: tokens.space('1x') tokens.space('three-quarter-x') }`)
+        ).toEqual('body{padding:1rem .75rem}');
       });
     });
 
-    describe("important", () => {
-      it("returns !important for booleans", () => {
-        expect(compile(`body { padding: 1rem important(true); }`)).toEqual(
-          "body{padding:1rem !important}"
+    describe('important', () => {
+      it('returns !important for booleans', () => {
+        expect(compile(`body { padding: 1rem tokens.important(true); }`)).toEqual(
+          'body{padding:1rem !important}'
         );
       });
 
-      it("returns null when null", () => {
-        expect(compile(`body { padding: 1rem important(); }`)).toEqual(
-          "body{padding:1rem}"
-        );
+      it('returns null when null', () => {
+        expect(compile(`body { padding: 1rem tokens.important(); }`)).toEqual('body{padding:1rem}');
       });
 
-      it("supports lists of properties", () => {
+      it('supports lists of properties', () => {
         expect(
-          compile(
-            `body { padding: 1rem important((padding, margin), padding); }`
-          )
-        ).toEqual("body{padding:1rem !important}");
+          compile(`body { padding: 1rem tokens.important((padding, margin), padding); }`)
+        ).toEqual('body{padding:1rem !important}');
       });
 
-      it("returns null if the property is not found in the list", () => {
+      it('returns null if the property is not found in the list', () => {
         expect(
-          compile(
-            `body { margin-left: 1rem important((padding, margin), margin-left); }`
-          )
-        ).toEqual("body{margin-left:1rem}");
+          compile(`body { margin-left: 1rem tokens.important((padding, margin), margin-left); }`)
+        ).toEqual('body{margin-left:1rem}');
       });
     });
   });
 
-  describe("mixins", () => {
-    describe("text", () => {
-      it("returns text treatments", () => {
-        expect(compile(`body { @include text(eyebrow); }`)).toEqual(
+  describe('mixins', () => {
+    describe('text', () => {
+      it('returns text treatments', () => {
+        expect(compile(`body { @include tokens.text(eyebrow); }`)).toEqual(
           'body{font-family:"Moda Operandi Sans",Arial,sans-serif;font-size:0.75rem;line-height:1.4;letter-spacing:0.1em;text-transform:uppercase}'
         );
       });
 
-      it("supports $important: true", () => {
-        expect(
-          compile(`body { @include text(eyebrow, $important: true); }`)
-        ).toEqual(
+      it('supports $important: true', () => {
+        expect(compile(`body { @include tokens.text(eyebrow, $important: true); }`)).toEqual(
           'body{font-family:"Moda Operandi Sans",Arial,sans-serif !important;font-size:0.75rem !important;line-height:1.4 !important;letter-spacing:0.1em !important;text-transform:uppercase !important}'
         );
       });
 
-      it("supports $important: (...)", () => {
+      it('supports $important: (...)', () => {
         expect(
-          compile(
-            `body { @include text(eyebrow, $important: (font-size, line-height)); }`
-          )
+          compile(`body { @include tokens.text(eyebrow, $important: (font-size, line-height)); }`)
         ).toEqual(
           'body{font-family:"Moda Operandi Sans",Arial,sans-serif;font-size:0.75rem !important;line-height:1.4 !important;letter-spacing:0.1em;text-transform:uppercase}'
         );


### PR DESCRIPTION
Fixes most sass deprecation warnings.

BREAKING CHANGE: Importing this package with `@import` will no longer work. Users will have to change to the `@use` syntax.

ECOM-4074